### PR TITLE
Revert "feat: pass TypeDef objects instead of type name string to `type` of field config"

### DIFF
--- a/packages/protoc-gen-nexus/src/__tests__/__snapshots__/process.test.ts.snap
+++ b/packages/protoc-gen-nexus/src/__tests__/__snapshots__/process.test.ts.snap
@@ -23,7 +23,7 @@ export const DeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(NotDeprecatedEnum),
+            type: nexus.nullable(\\"NotDeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.\\",
             resolve(root) {
                 const value = root.getEnum();
@@ -54,7 +54,7 @@ export const NotDeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedEnum),
+            type: nexus.nullable(\\"DeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.\\",
             resolve(root) {
                 const value = root.getEnum();
@@ -68,7 +68,7 @@ export const NotDeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"notDeprecatedOneof\\", {
-            type: nexus.nullable(NotDeprecatedMessageNotDeprecatedOneof),
+            type: nexus.nullable(\\"NotDeprecatedMessageNotDeprecatedOneof\\"),
             resolve(root) {
                 switch (root.getNotDeprecatedOneofCase()) {
                     case _$testapis$deprecation$deprecation_pb.NotDeprecatedMessage.NotDeprecatedOneofCase.NOT_DEPRECATED_ONEOF_NOT_SET: {
@@ -87,7 +87,7 @@ export const NotDeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"deprecatedOneof\\", {
-            type: nexus.nullable(NotDeprecatedMessageDeprecatedOneof),
+            type: nexus.nullable(\\"NotDeprecatedMessageDeprecatedOneof\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.deprecated_oneof is mark as deprecated in a *.proto file.\\",
             resolve(root) {
                 switch (root.getDeprecatedOneofCase()) {
@@ -169,7 +169,7 @@ export const DeprecatedMessageInput = nexus.inputObjectType({
             deprecation: \\"testapis.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(NotDeprecatedEnum),
+            type: nexus.nullable(\\"NotDeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.\\"
         });
     }
@@ -182,22 +182,22 @@ export const NotDeprecatedMessageInput = nexus.inputObjectType({
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedEnum),
+            type: nexus.nullable(\\"DeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"msg1\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage1Input),
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage1Input\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.msg1 is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"msg2\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage2Input)
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage2Input\\")
         });
         t.field(\\"msg3\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage1Input),
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage1Input\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"msg4\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage2Input),
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage2Input\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.\\"
         });
     }
@@ -230,13 +230,13 @@ export const NotDeprecatedMessageInnerMessage2Input = nexus.inputObjectType({
 export const NotDeprecatedMessageNotDeprecatedOneof = nexus.unionType({
     name: \\"NotDeprecatedMessageNotDeprecatedOneof\\",
     definition(t) {
-        t.members(NotDeprecatedMessageInnerMessage1, NotDeprecatedMessageInnerMessage2);
+        t.members(\\"NotDeprecatedMessageInnerMessage1\\", \\"NotDeprecatedMessageInnerMessage2\\");
     }
 });
 export const NotDeprecatedMessageDeprecatedOneof = nexus.unionType({
     name: \\"NotDeprecatedMessageDeprecatedOneof\\",
     definition(t) {
-        t.members(NotDeprecatedMessageInnerMessage1, NotDeprecatedMessageInnerMessage2);
+        t.members(\\"NotDeprecatedMessageInnerMessage1\\", \\"NotDeprecatedMessageInnerMessage2\\");
     }
 });
 export const NotDeprecatedEnum = nexus.enumType({
@@ -291,7 +291,7 @@ export const DeprecatedFileMessage = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedFileEnum),
+            type: nexus.nullable(\\"DeprecatedFileEnum\\"),
             deprecation: \\"testapis/deprecation/file_deprecation.proto is mark as deprecated.\\",
             resolve(root) {
                 const value = root.getEnum();
@@ -335,7 +335,7 @@ export const DeprecatedFileMessageInput = nexus.inputObjectType({
             deprecation: \\"testapis/deprecation/file_deprecation.proto is mark as deprecated.\\"
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedFileEnum),
+            type: nexus.nullable(\\"DeprecatedFileEnum\\"),
             deprecation: \\"testapis/deprecation/file_deprecation.proto is mark as deprecated.\\"
         });
     }
@@ -393,7 +393,7 @@ export const DeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(NotDeprecatedEnum),
+            type: nexus.nullable(\\"NotDeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.\\",
             resolve(root) {
                 const value = root.enum;
@@ -427,7 +427,7 @@ export const NotDeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedEnum),
+            type: nexus.nullable(\\"DeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.\\",
             resolve(root) {
                 const value = root.enum;
@@ -441,7 +441,7 @@ export const NotDeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"notDeprecatedOneof\\", {
-            type: nexus.nullable(NotDeprecatedMessageNotDeprecatedOneof),
+            type: nexus.nullable(\\"NotDeprecatedMessageNotDeprecatedOneof\\"),
             resolve(root) {
                 if (root.msg1) {
                     return root.msg1;
@@ -453,7 +453,7 @@ export const NotDeprecatedMessage = nexus.objectType({
             }
         });
         t.field(\\"deprecatedOneof\\", {
-            type: nexus.nullable(NotDeprecatedMessageDeprecatedOneof),
+            type: nexus.nullable(\\"NotDeprecatedMessageDeprecatedOneof\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.deprecated_oneof is mark as deprecated in a *.proto file.\\",
             resolve(root) {
                 if (root.msg3) {
@@ -537,7 +537,7 @@ export const DeprecatedMessageInput = nexus.inputObjectType({
             deprecation: \\"testapis.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(NotDeprecatedEnum),
+            type: nexus.nullable(\\"NotDeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedMessage is mark as deprecated in a *.proto file.\\"
         });
     }
@@ -550,22 +550,22 @@ export const NotDeprecatedMessageInput = nexus.inputObjectType({
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.body is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedEnum),
+            type: nexus.nullable(\\"DeprecatedEnum\\"),
             deprecation: \\"testapis.deprecation.DeprecatedEnum is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"msg1\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage1Input),
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage1Input\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.msg1 is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"msg2\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage2Input)
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage2Input\\")
         });
         t.field(\\"msg3\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage1Input),
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage1Input\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.msg3 is mark as deprecated in a *.proto file.\\"
         });
         t.field(\\"msg4\\", {
-            type: nexus.nullable(NotDeprecatedMessageInnerMessage2Input),
+            type: nexus.nullable(\\"NotDeprecatedMessageInnerMessage2Input\\"),
             deprecation: \\"testapis.deprecation.NotDeprecatedMessage.msg4 is mark as deprecated in a *.proto file.\\"
         });
     }
@@ -598,13 +598,13 @@ export const NotDeprecatedMessageInnerMessage2Input = nexus.inputObjectType({
 export const NotDeprecatedMessageNotDeprecatedOneof = nexus.unionType({
     name: \\"NotDeprecatedMessageNotDeprecatedOneof\\",
     definition(t) {
-        t.members(NotDeprecatedMessageInnerMessage1, NotDeprecatedMessageInnerMessage2);
+        t.members(\\"NotDeprecatedMessageInnerMessage1\\", \\"NotDeprecatedMessageInnerMessage2\\");
     }
 });
 export const NotDeprecatedMessageDeprecatedOneof = nexus.unionType({
     name: \\"NotDeprecatedMessageDeprecatedOneof\\",
     definition(t) {
-        t.members(NotDeprecatedMessageInnerMessage1, NotDeprecatedMessageInnerMessage2);
+        t.members(\\"NotDeprecatedMessageInnerMessage1\\", \\"NotDeprecatedMessageInnerMessage2\\");
     }
 });
 export const NotDeprecatedEnum = nexus.enumType({
@@ -662,7 +662,7 @@ export const DeprecatedFileMessage = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedFileEnum),
+            type: nexus.nullable(\\"DeprecatedFileEnum\\"),
             deprecation: \\"testapis/deprecation/file_deprecation.proto is mark as deprecated.\\",
             resolve(root) {
                 const value = root.enum;
@@ -709,7 +709,7 @@ export const DeprecatedFileMessageInput = nexus.inputObjectType({
             deprecation: \\"testapis/deprecation/file_deprecation.proto is mark as deprecated.\\"
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(DeprecatedFileEnum),
+            type: nexus.nullable(\\"DeprecatedFileEnum\\"),
             deprecation: \\"testapis/deprecation/file_deprecation.proto is mark as deprecated.\\"
         });
     }
@@ -753,7 +753,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
     name: \\"FieldBehaviorComentsMessage\\",
     definition(t) {
         t.field(\\"requiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePost),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.getRequiredField();
@@ -764,7 +764,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
             }
         });
         t.field(\\"requiredOutputOnlyField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePost),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Required. Output only.\\",
             resolve(root) {
                 const value = root.getRequiredOutputOnlyField();
@@ -775,7 +775,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
             }
         });
         t.field(\\"outputOnlyRequiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePost),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Output only. Required.\\",
             resolve(root) {
                 const value = root.getOutputOnlyRequiredField();
@@ -786,7 +786,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
             }
         });
         t.field(\\"outputOnlyField\\", {
-            type: nexus.nullable(FieldBehaviorComentsMessagePost),
+            type: nexus.nullable(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Output only.\\",
             resolve(root) {
                 const value = root.getOutputOnlyField();
@@ -822,19 +822,19 @@ export const FieldBehaviorComentsMessageInput = nexus.inputObjectType({
     name: \\"FieldBehaviorComentsMessageInput\\",
     definition(t) {
         t.field(\\"requiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Required.\\"
         });
         t.field(\\"requiredInputOnlyField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Required. Input only.\\"
         });
         t.field(\\"inputOnlyRequiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Input only. Required.\\"
         });
         t.field(\\"inputOnlyField\\", {
-            type: nexus.nullable(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nullable(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Input only.\\"
         });
     }
@@ -862,7 +862,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
     name: \\"FieldBehaviorComentsMessage\\",
     definition(t) {
         t.field(\\"requiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePost),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.requiredField;
@@ -873,7 +873,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
             }
         });
         t.field(\\"requiredOutputOnlyField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePost),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Required. Output only.\\",
             resolve(root) {
                 const value = root.requiredOutputOnlyField;
@@ -884,7 +884,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
             }
         });
         t.field(\\"outputOnlyRequiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePost),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Output only. Required.\\",
             resolve(root) {
                 const value = root.outputOnlyRequiredField;
@@ -895,7 +895,7 @@ export const FieldBehaviorComentsMessage = nexus.objectType({
             }
         });
         t.field(\\"outputOnlyField\\", {
-            type: nexus.nullable(FieldBehaviorComentsMessagePost),
+            type: nexus.nullable(\\"FieldBehaviorComentsMessagePost\\"),
             description: \\"Output only.\\",
             resolve(root) {
                 const value = root.outputOnlyField;
@@ -934,19 +934,19 @@ export const FieldBehaviorComentsMessageInput = nexus.inputObjectType({
     name: \\"FieldBehaviorComentsMessageInput\\",
     definition(t) {
         t.field(\\"requiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Required.\\"
         });
         t.field(\\"requiredInputOnlyField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Required. Input only.\\"
         });
         t.field(\\"inputOnlyRequiredField\\", {
-            type: nexus.nonNull(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nonNull(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Input only. Required.\\"
         });
         t.field(\\"inputOnlyField\\", {
-            type: nexus.nullable(FieldBehaviorComentsMessagePostInput),
+            type: nexus.nullable(\\"FieldBehaviorComentsMessagePostInput\\"),
             description: \\"Input only.\\"
         });
     }
@@ -1014,7 +1014,6 @@ exports[`multipkgs with native protobuf generates nexus DSLs: multipkgs/subpkg2/
 // source: testapis/multipkgs/subpkg2/types.proto
 
 import * as nexus from \\"nexus\\";
-import * as __$subpkg1$types_pb_nexus from \\"../subpkg1/types_pb_nexus\\";
 import * as _$testapis$multipkgs$subpkg1$types_pb from \\"./testapis/multipkgs/subpkg1/types_pb\\";
 import * as _$testapis$multipkgs$subpkg2$types_pb from \\"./testapis/multipkgs/subpkg2/types_pb\\";
 export type _$testapis$multipkgs$subpkg2$types_pb$MessageWithSubpkg = _$testapis$multipkgs$subpkg2$types_pb.MessageWithSubpkg;
@@ -1022,7 +1021,7 @@ export const MessageWithSubpkg = nexus.objectType({
     name: \\"MessageWithSubpkg\\",
     definition(t) {
         t.field(\\"message\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgMessage),
+            type: nexus.nullable(\\"SubpkgMessage\\"),
             resolve(root) {
                 const value = root.getMessage();
                 if (value == null) {
@@ -1032,7 +1031,7 @@ export const MessageWithSubpkg = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgEnum),
+            type: nexus.nullable(\\"SubpkgEnum\\"),
             resolve(root) {
                 const value = root.getEnum();
                 if (value == null) {
@@ -1054,10 +1053,10 @@ export const MessageWithSubpkgInput = nexus.inputObjectType({
     name: \\"MessageWithSubpkgInput\\",
     definition(t) {
         t.field(\\"message\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgMessageInput)
+            type: nexus.nullable(\\"SubpkgMessageInput\\")
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgEnum)
+            type: nexus.nullable(\\"SubpkgEnum\\")
         });
     }
 });
@@ -1119,7 +1118,6 @@ exports[`multipkgs with protobufjs generates nexus DSLs: multipkgs/subpkg2/types
 // source: testapis/multipkgs/subpkg2/types.proto
 
 import * as nexus from \\"nexus\\";
-import * as __$subpkg1$types_pb_nexus from \\"../subpkg1/types_pb_nexus\\";
 import * as _$testapis$multipkgs$subpkg1 from \\"./testapis/multipkgs/subpkg1\\";
 import * as _$testapis$multipkgs$subpkg2 from \\"./testapis/multipkgs/subpkg2\\";
 export type _$testapis$multipkgs$subpkg2$testapis$multipkgs$subpkg1$MessageWithSubpkg = _$testapis$multipkgs$subpkg2.testapis.multipkgs.subpkg1.MessageWithSubpkg;
@@ -1127,7 +1125,7 @@ export const MessageWithSubpkg = nexus.objectType({
     name: \\"MessageWithSubpkg\\",
     definition(t) {
         t.field(\\"message\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgMessage),
+            type: nexus.nullable(\\"SubpkgMessage\\"),
             resolve(root) {
                 const value = root.message;
                 if (value == null) {
@@ -1137,7 +1135,7 @@ export const MessageWithSubpkg = nexus.objectType({
             }
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgEnum),
+            type: nexus.nullable(\\"SubpkgEnum\\"),
             resolve(root) {
                 const value = root.enum;
                 if (value == null) {
@@ -1159,10 +1157,10 @@ export const MessageWithSubpkgInput = nexus.inputObjectType({
     name: \\"MessageWithSubpkgInput\\",
     definition(t) {
         t.field(\\"message\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgMessageInput)
+            type: nexus.nullable(\\"SubpkgMessageInput\\")
         });
         t.field(\\"enum\\", {
-            type: nexus.nullable(__$subpkg1$types_pb_nexus.SubpkgEnum)
+            type: nexus.nullable(\\"SubpkgEnum\\")
         });
     }
 });
@@ -1188,7 +1186,7 @@ export const ParentMessage = nexus.objectType({
             }
         });
         t.field(\\"nested\\", {
-            type: nexus.nullable(ParentMessageNestedMessage),
+            type: nexus.nullable(\\"ParentMessageNestedMessage\\"),
             resolve(root) {
                 const value = root.getNested();
                 if (value == null) {
@@ -1198,7 +1196,7 @@ export const ParentMessage = nexus.objectType({
             }
         });
         t.field(\\"nestedEnum\\", {
-            type: nexus.nullable(ParentMessageNestedEnum),
+            type: nexus.nullable(\\"ParentMessageNestedEnum\\"),
             resolve(root) {
                 const value = root.getNestedEnum();
                 if (value == null) {
@@ -1239,10 +1237,10 @@ export const ParentMessageInput = nexus.inputObjectType({
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"nested\\", {
-            type: nexus.nullable(ParentMessageNestedMessageInput)
+            type: nexus.nullable(\\"ParentMessageNestedMessageInput\\")
         });
         t.field(\\"nestedEnum\\", {
-            type: nexus.nullable(ParentMessageNestedEnum)
+            type: nexus.nullable(\\"ParentMessageNestedEnum\\")
         });
     }
 });
@@ -1292,7 +1290,7 @@ export const ParentMessage = nexus.objectType({
             }
         });
         t.field(\\"nested\\", {
-            type: nexus.nullable(ParentMessageNestedMessage),
+            type: nexus.nullable(\\"ParentMessageNestedMessage\\"),
             resolve(root) {
                 const value = root.nested;
                 if (value == null) {
@@ -1302,7 +1300,7 @@ export const ParentMessage = nexus.objectType({
             }
         });
         t.field(\\"nestedEnum\\", {
-            type: nexus.nullable(ParentMessageNestedEnum),
+            type: nexus.nullable(\\"ParentMessageNestedEnum\\"),
             resolve(root) {
                 const value = root.nestedEnum;
                 if (value == null) {
@@ -1346,10 +1344,10 @@ export const ParentMessageInput = nexus.inputObjectType({
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"nested\\", {
-            type: nexus.nullable(ParentMessageNestedMessageInput)
+            type: nexus.nullable(\\"ParentMessageNestedMessageInput\\")
         });
         t.field(\\"nestedEnum\\", {
-            type: nexus.nullable(ParentMessageNestedEnum)
+            type: nexus.nullable(\\"ParentMessageNestedEnum\\")
         });
     }
 });
@@ -1407,7 +1405,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"prefixedEnum\\", {
-            type: nexus.nullable(TestPrefixPrefixedEnum),
+            type: nexus.nullable(\\"TestPrefixPrefixedEnum\\"),
             resolve(root) {
                 const value = root.getPrefixedEnum();
                 if (value == null) {
@@ -1423,7 +1421,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"notIgnoredMessage\\", {
-            type: nexus.nullable(TestPrefixIgnoredMessageNotIgnored),
+            type: nexus.nullable(\\"TestPrefixIgnoredMessageNotIgnored\\"),
             resolve(root) {
                 const value = root.getNotIgnoredMessage();
                 if (value == null) {
@@ -1433,7 +1431,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"squashedMessage\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageSquashedMessage),
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageSquashedMessage\\"),
             resolve(root) {
                 const value = root.getSquashedMessage();
                 if (value == null) {
@@ -1463,7 +1461,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"partialIgnoreOneof\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessagePartialIgnoreOneof),
+            type: nexus.nullable(\\"TestPrefixPrefixedMessagePartialIgnoreOneof\\"),
             resolve(root) {
                 switch (root.getPartialIgnoreOneofCase()) {
                     case _$testapis$extensions$extensions_pb.PrefixedMessage.PartialIgnoreOneofCase.PARTIAL_IGNORE_ONEOF_NOT_SET: {
@@ -1553,19 +1551,19 @@ export const TestPrefixPrefixedMessageInput = nexus.inputObjectType({
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"prefixedEnum\\", {
-            type: nexus.nullable(TestPrefixPrefixedEnum)
+            type: nexus.nullable(\\"TestPrefixPrefixedEnum\\")
         });
         t.field(\\"notIgnoredMessage\\", {
-            type: nexus.nullable(TestPrefixIgnoredMessageNotIgnoredInput)
+            type: nexus.nullable(\\"TestPrefixIgnoredMessageNotIgnoredInput\\")
         });
         t.field(\\"squashedMessage\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageSquashedMessageInput)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageSquashedMessageInput\\")
         });
         t.field(\\"thisFieldWasRenamed\\", {
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"oneofNotIgnoredField\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageInnerMessageInput)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageInnerMessageInput\\")
         });
     }
 });
@@ -1603,10 +1601,10 @@ export const TestPrefixPrefixedMessageSquashedMessageInput = nexus.inputObjectTy
     name: \\"TestPrefixPrefixedMessageSquashedMessageInput\\",
     definition(t) {
         t.field(\\"oneofField\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageInnerMessageInput)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageInnerMessageInput\\")
         });
         t.field(\\"oneofField2\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageInnerMessage2Input)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageInnerMessage2Input\\")
         });
     }
 });
@@ -1633,13 +1631,13 @@ export const TestPrefixInterfaceMessage = nexus.interfaceType({
 export const TestPrefixPrefixedMessageSquashedMessage = nexus.unionType({
     name: \\"TestPrefixPrefixedMessageSquashedMessage\\",
     definition(t) {
-        t.members(TestPrefixPrefixedMessageInnerMessage, TestPrefixPrefixedMessageInnerMessage2);
+        t.members(\\"TestPrefixPrefixedMessageInnerMessage\\", \\"TestPrefixPrefixedMessageInnerMessage2\\");
     }
 });
 export const TestPrefixPrefixedMessagePartialIgnoreOneof = nexus.unionType({
     name: \\"TestPrefixPrefixedMessagePartialIgnoreOneof\\",
     definition(t) {
-        t.members(TestPrefixPrefixedMessageInnerMessage);
+        t.members(\\"TestPrefixPrefixedMessageInnerMessage\\");
     }
 });
 export const TestPrefixPrefixedEnum = nexus.enumType({
@@ -1715,7 +1713,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"prefixedEnum\\", {
-            type: nexus.nullable(TestPrefixPrefixedEnum),
+            type: nexus.nullable(\\"TestPrefixPrefixedEnum\\"),
             resolve(root) {
                 const value = root.prefixedEnum;
                 if (value == null) {
@@ -1731,7 +1729,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"notIgnoredMessage\\", {
-            type: nexus.nullable(TestPrefixIgnoredMessageNotIgnored),
+            type: nexus.nullable(\\"TestPrefixIgnoredMessageNotIgnored\\"),
             resolve(root) {
                 const value = root.notIgnoredMessage;
                 if (value == null) {
@@ -1741,7 +1739,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"squashedMessage\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageSquashedMessage),
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageSquashedMessage\\"),
             resolve(root) {
                 const value = root.squashedMessage;
                 if (value == null) {
@@ -1767,7 +1765,7 @@ export const TestPrefixPrefixedMessage = nexus.objectType({
             }
         });
         t.field(\\"partialIgnoreOneof\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessagePartialIgnoreOneof),
+            type: nexus.nullable(\\"TestPrefixPrefixedMessagePartialIgnoreOneof\\"),
             resolve(root) {
                 if (root.oneofNotIgnoredField) {
                     return root.oneofNotIgnoredField;
@@ -1865,19 +1863,19 @@ export const TestPrefixPrefixedMessageInput = nexus.inputObjectType({
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"prefixedEnum\\", {
-            type: nexus.nullable(TestPrefixPrefixedEnum)
+            type: nexus.nullable(\\"TestPrefixPrefixedEnum\\")
         });
         t.field(\\"notIgnoredMessage\\", {
-            type: nexus.nullable(TestPrefixIgnoredMessageNotIgnoredInput)
+            type: nexus.nullable(\\"TestPrefixIgnoredMessageNotIgnoredInput\\")
         });
         t.field(\\"squashedMessage\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageSquashedMessageInput)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageSquashedMessageInput\\")
         });
         t.field(\\"thisFieldWasRenamed\\", {
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"oneofNotIgnoredField\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageInnerMessageInput)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageInnerMessageInput\\")
         });
     }
 });
@@ -1915,10 +1913,10 @@ export const TestPrefixPrefixedMessageSquashedMessageInput = nexus.inputObjectTy
     name: \\"TestPrefixPrefixedMessageSquashedMessageInput\\",
     definition(t) {
         t.field(\\"oneofField\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageInnerMessageInput)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageInnerMessageInput\\")
         });
         t.field(\\"oneofField2\\", {
-            type: nexus.nullable(TestPrefixPrefixedMessageInnerMessage2Input)
+            type: nexus.nullable(\\"TestPrefixPrefixedMessageInnerMessage2Input\\")
         });
     }
 });
@@ -1948,13 +1946,13 @@ export const TestPrefixInterfaceMessage = nexus.interfaceType({
 export const TestPrefixPrefixedMessageSquashedMessage = nexus.unionType({
     name: \\"TestPrefixPrefixedMessageSquashedMessage\\",
     definition(t) {
-        t.members(TestPrefixPrefixedMessageInnerMessage, TestPrefixPrefixedMessageInnerMessage2);
+        t.members(\\"TestPrefixPrefixedMessageInnerMessage\\", \\"TestPrefixPrefixedMessageInnerMessage2\\");
     }
 });
 export const TestPrefixPrefixedMessagePartialIgnoreOneof = nexus.unionType({
     name: \\"TestPrefixPrefixedMessagePartialIgnoreOneof\\",
     definition(t) {
-        t.members(TestPrefixPrefixedMessageInnerMessage);
+        t.members(\\"TestPrefixPrefixedMessageInnerMessage\\");
     }
 });
 export const TestPrefixPrefixedEnum = nexus.enumType({
@@ -2005,7 +2003,7 @@ export const MessageWithEnums = nexus.objectType({
     name: \\"MessageWithEnums\\",
     definition(t) {
         t.field(\\"requiredMyEnum\\", {
-            type: nexus.nonNull(MyEnum),
+            type: nexus.nonNull(\\"MyEnum\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.getRequiredMyEnum();
@@ -2019,7 +2017,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnum\\", {
-            type: nexus.nullable(MyEnum),
+            type: nexus.nullable(\\"MyEnum\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.getOptionalMyEnum();
@@ -2033,7 +2031,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"requiredMyEnumWithoutUnspecified\\", {
-            type: nexus.nonNull(MyEnumWithoutUnspecified),
+            type: nexus.nonNull(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.getRequiredMyEnumWithoutUnspecified();
@@ -2044,7 +2042,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnumWithoutUnspecified\\", {
-            type: nexus.nullable(MyEnumWithoutUnspecified),
+            type: nexus.nullable(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.getOptionalMyEnumWithoutUnspecified();
@@ -2055,7 +2053,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"requiredMyEnums\\", {
-            type: nexus.list(nexus.nonNull(MyEnum)),
+            type: nexus.list(nexus.nonNull(\\"MyEnum\\")),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.getRequiredMyEnumsList();
@@ -2068,7 +2066,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnums\\", {
-            type: nexus.list(nexus.nullable(MyEnum)),
+            type: nexus.list(nexus.nullable(\\"MyEnum\\")),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.getOptionalMyEnumsList();
@@ -2081,7 +2079,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"requiredMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nonNull(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nonNull(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.getRequiredMyEnumWithoutUnspecifiedsList();
@@ -2089,7 +2087,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nullable(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nullable(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.getOptionalMyEnumWithoutUnspecifiedsList();
@@ -2106,35 +2104,35 @@ export const MessageWithEnumsInput = nexus.inputObjectType({
     name: \\"MessageWithEnumsInput\\",
     definition(t) {
         t.field(\\"requiredMyEnum\\", {
-            type: nexus.nonNull(MyEnum),
+            type: nexus.nonNull(\\"MyEnum\\"),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnum\\", {
-            type: nexus.nullable(MyEnum),
+            type: nexus.nullable(\\"MyEnum\\"),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredMyEnumWithoutUnspecified\\", {
-            type: nexus.nonNull(MyEnumWithoutUnspecified),
+            type: nexus.nonNull(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnumWithoutUnspecified\\", {
-            type: nexus.nullable(MyEnumWithoutUnspecified),
+            type: nexus.nullable(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredMyEnums\\", {
-            type: nexus.list(nexus.nonNull(MyEnum)),
+            type: nexus.list(nexus.nonNull(\\"MyEnum\\")),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnums\\", {
-            type: nexus.list(nexus.nullable(MyEnum)),
+            type: nexus.list(nexus.nullable(\\"MyEnum\\")),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nonNull(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nonNull(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nullable(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nullable(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Optional.\\"
         });
     }
@@ -2188,7 +2186,7 @@ export const MessageWithEnums = nexus.objectType({
     name: \\"MessageWithEnums\\",
     definition(t) {
         t.field(\\"requiredMyEnum\\", {
-            type: nexus.nonNull(MyEnum),
+            type: nexus.nonNull(\\"MyEnum\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.requiredMyEnum;
@@ -2202,7 +2200,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnum\\", {
-            type: nexus.nullable(MyEnum),
+            type: nexus.nullable(\\"MyEnum\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.optionalMyEnum;
@@ -2216,7 +2214,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"requiredMyEnumWithoutUnspecified\\", {
-            type: nexus.nonNull(MyEnumWithoutUnspecified),
+            type: nexus.nonNull(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.requiredMyEnumWithoutUnspecified;
@@ -2227,7 +2225,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnumWithoutUnspecified\\", {
-            type: nexus.nullable(MyEnumWithoutUnspecified),
+            type: nexus.nullable(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.optionalMyEnumWithoutUnspecified;
@@ -2238,7 +2236,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"requiredMyEnums\\", {
-            type: nexus.list(nexus.nonNull(MyEnum)),
+            type: nexus.list(nexus.nonNull(\\"MyEnum\\")),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.requiredMyEnums;
@@ -2254,7 +2252,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnums\\", {
-            type: nexus.list(nexus.nullable(MyEnum)),
+            type: nexus.list(nexus.nullable(\\"MyEnum\\")),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.optionalMyEnums;
@@ -2270,7 +2268,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"requiredMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nonNull(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nonNull(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.requiredMyEnumWithoutUnspecifieds;
@@ -2281,7 +2279,7 @@ export const MessageWithEnums = nexus.objectType({
             }
         });
         t.field(\\"optionalMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nullable(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nullable(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.optionalMyEnumWithoutUnspecifieds;
@@ -2301,35 +2299,35 @@ export const MessageWithEnumsInput = nexus.inputObjectType({
     name: \\"MessageWithEnumsInput\\",
     definition(t) {
         t.field(\\"requiredMyEnum\\", {
-            type: nexus.nonNull(MyEnum),
+            type: nexus.nonNull(\\"MyEnum\\"),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnum\\", {
-            type: nexus.nullable(MyEnum),
+            type: nexus.nullable(\\"MyEnum\\"),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredMyEnumWithoutUnspecified\\", {
-            type: nexus.nonNull(MyEnumWithoutUnspecified),
+            type: nexus.nonNull(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnumWithoutUnspecified\\", {
-            type: nexus.nullable(MyEnumWithoutUnspecified),
+            type: nexus.nullable(\\"MyEnumWithoutUnspecified\\"),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredMyEnums\\", {
-            type: nexus.list(nexus.nonNull(MyEnum)),
+            type: nexus.list(nexus.nonNull(\\"MyEnum\\")),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnums\\", {
-            type: nexus.list(nexus.nullable(MyEnum)),
+            type: nexus.list(nexus.nullable(\\"MyEnum\\")),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nonNull(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nonNull(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Required.\\"
         });
         t.field(\\"optionalMyEnumWithoutUnspecifieds\\", {
-            type: nexus.list(nexus.nullable(MyEnumWithoutUnspecified)),
+            type: nexus.list(nexus.nullable(\\"MyEnumWithoutUnspecified\\")),
             description: \\"Optional.\\"
         });
     }
@@ -2392,7 +2390,7 @@ export const OneofParent = nexus.objectType({
             }
         });
         t.field(\\"requiredOneofMembers\\", {
-            type: nexus.nonNull(OneofParentRequiredOneofMembers),
+            type: nexus.nonNull(\\"OneofParentRequiredOneofMembers\\"),
             description: \\"Required. disallow not_set.\\",
             resolve(root) {
                 switch (root.getRequiredOneofMembersCase()) {
@@ -2412,7 +2410,7 @@ export const OneofParent = nexus.objectType({
             }
         });
         t.field(\\"optionalOneofMembers\\", {
-            type: nexus.nullable(OneofParentOptionalOneofMembers),
+            type: nexus.nullable(\\"OneofParentOptionalOneofMembers\\"),
             resolve(root) {
                 switch (root.getOptionalOneofMembersCase()) {
                     case _$testapis$oneof$oneof_pb.OneofParent.OptionalOneofMembersCase.OPTIONAL_ONEOF_MEMBERS_NOT_SET: {
@@ -2475,16 +2473,16 @@ export const OneofParentInput = nexus.inputObjectType({
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"requiredMessage1\\", {
-            type: nexus.nullable(OneofMemberMessage1Input)
+            type: nexus.nullable(\\"OneofMemberMessage1Input\\")
         });
         t.field(\\"requiredMessage2\\", {
-            type: nexus.nullable(OneofMemberMessage2Input)
+            type: nexus.nullable(\\"OneofMemberMessage2Input\\")
         });
         t.field(\\"optoinalMessage1\\", {
-            type: nexus.nullable(OneofMemberMessage1Input)
+            type: nexus.nullable(\\"OneofMemberMessage1Input\\")
         });
         t.field(\\"optoinalMessage2\\", {
-            type: nexus.nullable(OneofMemberMessage2Input)
+            type: nexus.nullable(\\"OneofMemberMessage2Input\\")
         });
     }
 });
@@ -2508,13 +2506,13 @@ export const OneofParentRequiredOneofMembers = nexus.unionType({
     name: \\"OneofParentRequiredOneofMembers\\",
     description: \\"Required. disallow not_set.\\",
     definition(t) {
-        t.members(OneofMemberMessage1, OneofMemberMessage2);
+        t.members(\\"OneofMemberMessage1\\", \\"OneofMemberMessage2\\");
     }
 });
 export const OneofParentOptionalOneofMembers = nexus.unionType({
     name: \\"OneofParentOptionalOneofMembers\\",
     definition(t) {
-        t.members(OneofMemberMessage1, OneofMemberMessage2);
+        t.members(\\"OneofMemberMessage1\\", \\"OneofMemberMessage2\\");
     }
 });
 "
@@ -2543,7 +2541,7 @@ export const OneofParent = nexus.objectType({
             }
         });
         t.field(\\"requiredOneofMembers\\", {
-            type: nexus.nonNull(OneofParentRequiredOneofMembers),
+            type: nexus.nonNull(\\"OneofParentRequiredOneofMembers\\"),
             description: \\"Required. disallow not_set.\\",
             resolve(root) {
                 if (root.requiredMessage1) {
@@ -2556,7 +2554,7 @@ export const OneofParent = nexus.objectType({
             }
         });
         t.field(\\"optionalOneofMembers\\", {
-            type: nexus.nullable(OneofParentOptionalOneofMembers),
+            type: nexus.nullable(\\"OneofParentOptionalOneofMembers\\"),
             resolve(root) {
                 if (root.optoinalMessage1) {
                     return root.optoinalMessage1;
@@ -2618,16 +2616,16 @@ export const OneofParentInput = nexus.inputObjectType({
             type: nexus.nonNull(\\"String\\")
         });
         t.field(\\"requiredMessage1\\", {
-            type: nexus.nullable(OneofMemberMessage1Input)
+            type: nexus.nullable(\\"OneofMemberMessage1Input\\")
         });
         t.field(\\"requiredMessage2\\", {
-            type: nexus.nullable(OneofMemberMessage2Input)
+            type: nexus.nullable(\\"OneofMemberMessage2Input\\")
         });
         t.field(\\"optoinalMessage1\\", {
-            type: nexus.nullable(OneofMemberMessage1Input)
+            type: nexus.nullable(\\"OneofMemberMessage1Input\\")
         });
         t.field(\\"optoinalMessage2\\", {
-            type: nexus.nullable(OneofMemberMessage2Input)
+            type: nexus.nullable(\\"OneofMemberMessage2Input\\")
         });
     }
 });
@@ -2651,13 +2649,13 @@ export const OneofParentRequiredOneofMembers = nexus.unionType({
     name: \\"OneofParentRequiredOneofMembers\\",
     description: \\"Required. disallow not_set.\\",
     definition(t) {
-        t.members(OneofMemberMessage1, OneofMemberMessage2);
+        t.members(\\"OneofMemberMessage1\\", \\"OneofMemberMessage2\\");
     }
 });
 export const OneofParentOptionalOneofMembers = nexus.unionType({
     name: \\"OneofParentOptionalOneofMembers\\",
     definition(t) {
-        t.members(OneofMemberMessage1, OneofMemberMessage2);
+        t.members(\\"OneofMemberMessage1\\", \\"OneofMemberMessage2\\");
     }
 });
 "
@@ -2675,7 +2673,7 @@ export const Hello = nexus.objectType({
     name: \\"Hello\\",
     definition(t) {
         t.field(\\"requiredPrimitives\\", {
-            type: nexus.nonNull(Primitives),
+            type: nexus.nonNull(\\"Primitives\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.getRequiredPrimitives();
@@ -2686,7 +2684,7 @@ export const Hello = nexus.objectType({
             }
         });
         t.field(\\"optionalPrimitives\\", {
-            type: nexus.nullable(Primitives),
+            type: nexus.nullable(\\"Primitives\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.getOptionalPrimitives();
@@ -2697,7 +2695,7 @@ export const Hello = nexus.objectType({
             }
         });
         t.field(\\"requiredPrimitivesList\\", {
-            type: nexus.list(nexus.nonNull(Primitives)),
+            type: nexus.list(nexus.nonNull(\\"Primitives\\")),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.getRequiredPrimitivesListList();
@@ -2705,7 +2703,7 @@ export const Hello = nexus.objectType({
             }
         });
         t.field(\\"optionalPrimitivesList\\", {
-            type: nexus.nullable(Primitives),
+            type: nexus.nullable(\\"Primitives\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.getOptionalPrimitivesList();
@@ -2940,19 +2938,19 @@ export const HelloInput = nexus.inputObjectType({
     name: \\"HelloInput\\",
     definition(t) {
         t.field(\\"requiredPrimitives\\", {
-            type: nexus.nonNull(PrimitivesInput),
+            type: nexus.nonNull(\\"PrimitivesInput\\"),
             description: \\"Required.\\"
         });
         t.field(\\"optionalPrimitives\\", {
-            type: nexus.nullable(PrimitivesInput),
+            type: nexus.nullable(\\"PrimitivesInput\\"),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredPrimitivesList\\", {
-            type: nexus.list(nexus.nonNull(PrimitivesInput)),
+            type: nexus.list(nexus.nonNull(\\"PrimitivesInput\\")),
             description: \\"Required.\\"
         });
         t.field(\\"optionalPrimitivesList\\", {
-            type: nexus.nullable(PrimitivesInput),
+            type: nexus.nullable(\\"PrimitivesInput\\"),
             description: \\"Optional.\\"
         });
     }
@@ -3061,7 +3059,7 @@ export const Hello = nexus.objectType({
     name: \\"Hello\\",
     definition(t) {
         t.field(\\"requiredPrimitives\\", {
-            type: nexus.nonNull(Primitives),
+            type: nexus.nonNull(\\"Primitives\\"),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.requiredPrimitives;
@@ -3072,7 +3070,7 @@ export const Hello = nexus.objectType({
             }
         });
         t.field(\\"optionalPrimitives\\", {
-            type: nexus.nullable(Primitives),
+            type: nexus.nullable(\\"Primitives\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.optionalPrimitives;
@@ -3083,7 +3081,7 @@ export const Hello = nexus.objectType({
             }
         });
         t.field(\\"requiredPrimitivesList\\", {
-            type: nexus.list(nexus.nonNull(Primitives)),
+            type: nexus.list(nexus.nonNull(\\"Primitives\\")),
             description: \\"Required.\\",
             resolve(root) {
                 const value = root.requiredPrimitivesList;
@@ -3094,7 +3092,7 @@ export const Hello = nexus.objectType({
             }
         });
         t.field(\\"optionalPrimitivesList\\", {
-            type: nexus.nullable(Primitives),
+            type: nexus.nullable(\\"Primitives\\"),
             description: \\"Optional.\\",
             resolve(root) {
                 const value = root.optionalPrimitivesList;
@@ -3413,19 +3411,19 @@ export const HelloInput = nexus.inputObjectType({
     name: \\"HelloInput\\",
     definition(t) {
         t.field(\\"requiredPrimitives\\", {
-            type: nexus.nonNull(PrimitivesInput),
+            type: nexus.nonNull(\\"PrimitivesInput\\"),
             description: \\"Required.\\"
         });
         t.field(\\"optionalPrimitives\\", {
-            type: nexus.nullable(PrimitivesInput),
+            type: nexus.nullable(\\"PrimitivesInput\\"),
             description: \\"Optional.\\"
         });
         t.field(\\"requiredPrimitivesList\\", {
-            type: nexus.list(nexus.nonNull(PrimitivesInput)),
+            type: nexus.list(nexus.nonNull(\\"PrimitivesInput\\")),
             description: \\"Required.\\"
         });
         t.field(\\"optionalPrimitivesList\\", {
-            type: nexus.nullable(PrimitivesInput),
+            type: nexus.nullable(\\"PrimitivesInput\\"),
             description: \\"Optional.\\"
         });
     }

--- a/packages/protoc-gen-nexus/src/dslgen/printers/field.ts
+++ b/packages/protoc-gen-nexus/src/dslgen/printers/field.ts
@@ -2,7 +2,6 @@ import ts from "typescript";
 import {
   createDeprecationPropertyAssignment,
   createDescriptionPropertyAssignment,
-  createFullNameExpr,
   createNexusCallExpr,
   onlyNonNull,
 } from "./util";
@@ -42,7 +41,7 @@ export function createFieldDefinitionStmt(
  */
 function createFieldOptionExpr(field: ObjectField<any> | ObjectOneofField | InputObjectField<any>): ts.Expression {
   let typeExpr: ts.Expression = createNexusCallExpr(field.isNullable() ? "nullable" : "nonNull", [
-    field.typeFullName ? createFullNameExpr(field.typeFullName) : ts.factory.createStringLiteral(field.type.typeName),
+    ts.factory.createStringLiteral(field.type.typeName),
   ]);
   if (field.isList()) {
     typeExpr = createNexusCallExpr("list", [typeExpr]);

--- a/packages/protoc-gen-nexus/src/dslgen/printers/oneofUnionType.ts
+++ b/packages/protoc-gen-nexus/src/dslgen/printers/oneofUnionType.ts
@@ -3,7 +3,6 @@ import { OneofUnionType, SquashedOneofUnionType } from "../types";
 import {
   createDescriptionPropertyAssignment,
   createDslExportConstStmt,
-  createFullNameExpr,
   createNexusCallExpr,
   onlyNonNull,
 } from "./util";
@@ -60,7 +59,7 @@ function createOneofUnionTypeDefinitionMethodDecl(type: OneofUnionType | Squashe
               ts.factory.createIdentifier("members")
             ),
             undefined,
-            type.fields.map((f) => createFullNameExpr(f.typeFullName!))
+            type.fields.map((f) => ts.factory.createStringLiteral(f.type.typeName))
           )
         ),
       ],

--- a/packages/protoc-gen-nexus/src/dslgen/printers/util.ts
+++ b/packages/protoc-gen-nexus/src/dslgen/printers/util.ts
@@ -59,30 +59,21 @@ export function createDeprecationPropertyAssignment(
   return ts.factory.createPropertyAssignment("deprecation", ts.factory.createStringLiteral(reason));
 }
 
-export function fullNameString(fn: FullName): string {
-  if (typeof fn === "string") {
-    return fn;
-  }
-  return `${typeof fn[0] === "string" ? fn[0] : fullNameString(fn[0])}.${fn[1]}`;
+export function fullNameString([left, name]: FullName): string {
+  return `${typeof left === "string" ? left : fullNameString(left)}.${name}`;
 }
 
-export function createFullNameExpr(fn: FullName): ts.Expression {
-  if (typeof fn === "string") {
-    return ts.factory.createIdentifier(fn);
-  }
+export function createFullNameExpr([left, name]: FullName): ts.Expression {
   return ts.factory.createPropertyAccessExpression(
-    typeof fn[0] === "string" ? ts.factory.createIdentifier(fn[0]) : createFullNameExpr(fn[0]),
-    fn[1]
+    typeof left === "string" ? ts.factory.createIdentifier(left) : createFullNameExpr(left),
+    name
   );
 }
 
-export function createQualifiedName(fn: FullName): ts.Identifier | ts.QualifiedName {
-  if (typeof fn === "string") {
-    return ts.factory.createIdentifier(fn);
-  }
+export function createQualifiedName([left, name]: FullName): ts.QualifiedName {
   return ts.factory.createQualifiedName(
-    typeof fn[0] === "string" ? ts.factory.createIdentifier(fn[0]) : createQualifiedName(fn[0]),
-    fn[1]
+    typeof left === "string" ? ts.factory.createIdentifier(left) : createQualifiedName(left),
+    name
   );
 }
 

--- a/packages/protoc-gen-nexus/src/dslgen/types/types.ts
+++ b/packages/protoc-gen-nexus/src/dslgen/types/types.ts
@@ -1,5 +1,4 @@
 import ts from "typescript";
-import path from "path";
 import assert from "assert";
 import {
   CommentSet,
@@ -28,7 +27,6 @@ import {
   GenerationParams,
   FullName,
   modulesWithUniqueImportAlias,
-  uniqueImportAlias,
 } from "./util";
 import * as extensions from "../../__generated__/extensions/graphql/schema_pb";
 import { camelCase, constantCase } from "change-case";
@@ -112,7 +110,7 @@ export class DslFile {
 }
 
 abstract class TypeBase<P extends ProtoMessage | ProtoEnum | ProtoOneof> {
-  constructor(protected readonly proto: P, readonly file: DslFile) {}
+  constructor(protected readonly proto: P, protected readonly file: DslFile) {}
 
   get typeName(): string {
     return gqlTypeName(this.proto);
@@ -172,7 +170,7 @@ export class ObjectType extends TypeBase<ProtoMessage> {
         .filter((f) => f.containingOneof == null)
         .filter((f) => !isInputOnlyField(f))
         .filter((f) => !isIgnoredField(f))
-        .map((f) => new ObjectField(getObjectFieldType(f, this.options), this, f, this.options)),
+        .map((f) => new ObjectField(getObjectFieldType(f, this.options), f, this.options)),
       ...this.proto.oneofs
         .filter((f) => !isInputOnlyField(f))
         .filter((f) => !isIgnoredField(f))
@@ -216,12 +214,7 @@ abstract class FieldBase<P extends ProtoField | ProtoOneof> {
 export class ObjectField<
   T extends ObjectType | InterfaceType | SquashedOneofUnionType | EnumType | ScalarType
 > extends FieldBase<ProtoField> {
-  constructor(
-    readonly type: T,
-    private readonly parent: ObjectType | OneofUnionType,
-    proto: ProtoField,
-    opts: GenerationParams
-  ) {
+  constructor(readonly type: T, proto: ProtoField, opts: GenerationParams) {
     super(proto, opts);
   }
 
@@ -251,9 +244,6 @@ export class ObjectField<
     if (this.type instanceof EnumType && this.type.unspecifiedValue != null) {
       modules.push(this.type.protoImportPath);
     }
-    if (this.typeImportPath) {
-      modules.push(this.typeImportPath);
-    }
     return modulesWithUniqueImportAlias(modules);
   }
 
@@ -266,26 +256,6 @@ export class ObjectField<
     if (this.type instanceof ScalarType && this.type.isPrimitive()) return false;
 
     return true;
-  }
-
-  get typeFullName(): FullName | null {
-    if (this.type instanceof ScalarType) return null;
-    if (!this.typeImportPath) {
-      return this.type.typeName;
-    }
-    return [uniqueImportAlias(this.typeImportPath), this.type.typeName];
-  }
-
-  private get typeImportPath(): string | null {
-    const type: ObjectType | InterfaceType | SquashedOneofUnionType | EnumType | ScalarType = this.type;
-
-    if (type instanceof ScalarType) return null;
-    if (this.parent.file.filename === type.file.filename) return null;
-
-    const [from, to] = [this.parent.file, type.file].map((f) =>
-      path.isAbsolute(f.filename) ? `.${path.sep}${f.filename}` : f.filename
-    );
-    return path.relative(path.dirname(from), to).replace(/\.ts$/, "");
   }
 
   public getProtoFieldAccessExpr(parentExpr: ts.Expression): ts.Expression {
@@ -335,10 +305,6 @@ export class ObjectOneofField extends FieldBase<ProtoOneof> {
   get importModules(): { alias: string; module: string }[] {
     return this.type.fields.flatMap((f) => f.importModules);
   }
-
-  get typeFullName(): FullName | null {
-    return this.type.typeName;
-  }
 }
 
 export class InputObjectType extends TypeBase<ProtoMessage> {
@@ -354,18 +320,13 @@ export class InputObjectType extends TypeBase<ProtoMessage> {
       ...this.proto.fields
         .filter((f) => !isOutputOnlyField(f))
         .filter((f) => !isIgnoredField(f))
-        .map((f) => new InputObjectField(getInputObjectFieldType(f, this.options), this, f, this.options)),
+        .map((f) => new InputObjectField(getInputObjectFieldType(f, this.options), f, this.options)),
     ];
   }
 }
 
 export class InputObjectField<T extends ScalarType | EnumType | InputObjectType> {
-  constructor(
-    readonly type: T,
-    private readonly parent: InputObjectType,
-    private readonly proto: ProtoField,
-    private readonly opts: GenerationParams
-  ) {}
+  constructor(readonly type: T, private readonly proto: ProtoField, private readonly opts: GenerationParams) {}
 
   get name(): string {
     return this.proto.descriptor.getOptions()?.getExtension(extensions.field)?.getName() || this.proto.jsonName;
@@ -388,26 +349,6 @@ export class InputObjectField<T extends ScalarType | EnumType | InputObjectType>
     if (isRequiredField(this.proto)) return false;
     return this.type instanceof ScalarType ? !this.type.isPrimitive() : true;
   }
-
-  get typeFullName(): FullName | null {
-    if (this.type instanceof ScalarType) return null;
-    if (!this.typeImportPath) {
-      return this.type.typeName;
-    }
-    return [uniqueImportAlias(this.typeImportPath), this.type.typeName];
-  }
-
-  private get typeImportPath(): string | null {
-    const type: InputObjectType | EnumType | ScalarType = this.type;
-
-    if (type instanceof ScalarType) return null;
-    if (this.parent.file.filename === type.file.filename) return null;
-
-    const [from, to] = [this.parent.file, type.file].map((f) =>
-      path.isAbsolute(f.filename) ? `.${path.sep}${f.filename}` : f.filename
-    );
-    return path.relative(path.dirname(from), to).replace(/\.ts$/, "");
-  }
 }
 
 export class InterfaceType extends ObjectType {}
@@ -421,7 +362,7 @@ export class OneofUnionType extends TypeBase<ProtoOneof> {
         const type = getObjectFieldType(f, this.options);
         // FIXME: raise user-friendly error
         assert(type instanceof ObjectType);
-        return new ObjectField(type, this, f, this.options);
+        return new ObjectField(type, f, this.options);
       });
   }
 

--- a/packages/protoc-gen-nexus/src/dslgen/types/util.ts
+++ b/packages/protoc-gen-nexus/src/dslgen/types/util.ts
@@ -18,7 +18,7 @@ export type GenerationParams = {
   useProtobufjs: boolean;
 };
 
-export type FullName = [FullName, string] | string;
+export type FullName = [FullName | string, string];
 
 /**
  * @example js_out
@@ -32,7 +32,7 @@ export type FullName = [FullName, string] | string;
  * ```
  */
 export function createProtoFullName(t: ProtoMessage | ProtoEnum, o: GenerationParams): FullName {
-  let left: FullName;
+  let left: FullName[0];
   if (t.parent.kind === "File") {
     if (o.useProtobufjs) {
       const pkgs = t.parent.package.split(".");


### PR DESCRIPTION
Reverts proto-graphql/proto-nexus#91

After testing this in my own product, I thought it would be better to specify the dependent types explicitly...