### PR TITLE
Fixing the process of converting to timestamp

### DIFF
--- a/packages/@proto-nexus/google-protobuf/src/timestamp.ts
+++ b/packages/@proto-nexus/google-protobuf/src/timestamp.ts
@@ -12,7 +12,8 @@ registerTransformer("google.protobuf.Timestamp", {
     return new Date(v.getSeconds() * 1000 + v.getNanos() / 1e6) as any;
   },
   gqlToProto(v) {
-    const ms = v.getTime();
-    return new Timestamp().setSeconds(ms / 1000).setNanos(ms * 1e6) as any;
+    const s = Math.floor(v.getTime() / 1000)
+    const ns = v.getMilliseconds() * 1e6
+    return new Timestamp().setSeconds(s).setNanos(ns)
   },
 });


### PR DESCRIPTION
Date in js was not converted correctly to Timestamp in protobuf.
So, modify gqlToProto method of transformer to convert correctly.